### PR TITLE
Fixed most of plugin issues and added RespawnTimer support

### DIFF
--- a/Config.cs
+++ b/Config.cs
@@ -14,8 +14,7 @@ namespace UIURescueSquad
         [Description("Probability of a UIU Squad replacing a MTF spawn")]
         public int probability { get; set; } = 50;
 
-        [Description("Use hints instead of broadcasts?")]
-        public bool UseHints { get; set; } = false;
+
         [Description("Entrance broadcast announcement message (null to disable it)")]
         public string AnnouncementText { get; set; } = "<b>The <color=#FFFA4B>UIU Rescue Squad</color> has arrived to the facility</b>";
         [Description("Entrance broadcast announcement message time")]
@@ -24,7 +23,8 @@ namespace UIURescueSquad
         [Description("Disable NTF default Announce")]
         public bool DisableNTFAnnounce { get; set; } = true;
         [Description("**ONLY WORKS IF DisableNTFAnnounce = true** Entrance Cassie Message")]
-        public string AnnouncementCassie { get; set; } = "The U I U Squad Has Entered The Facility AwaitingRecontainment";
+        public string AnnouncementCassie { get; set; } = "The U I U Squad HasEntered AwaitingRecontainment {scpnum}";
+        public string AnnouncmentCassieNoScp { get; set; } = "The U I U Squad HasEntered NoSCPsLeft";
 
 
         [Description("Use hints instead of broadcasts?")]
@@ -38,6 +38,13 @@ namespace UIURescueSquad
         public int UIUSoldierLife { get; set; } = 160;
         [Description("The items UIUs soldiers spawn with.")]
         public List<ItemType> UIUSoldierInventory { get; set; } = new List<ItemType>() { ItemType.KeycardNTFLieutenant, ItemType.GunProject90, ItemType.GunUSP, ItemType.Disarmer, ItemType.Medkit, ItemType.Adrenaline, ItemType.Radio, ItemType.GrenadeFrag };
+
+        [Description("Ammo UIUs soldiers spawn with. (5.56, 7.62, 9mm)")]
+        public List<uint> UIUSoldierAmmo { get; set; } = new List<uint>
+        {
+            80,0,100
+        };
+
         [Description("UIU Soldier Rank (THE BADGE ON THE LIST)")]
         public string UIUSoldierRank { get; set; } = "UIU Soldier";
 
@@ -45,6 +52,13 @@ namespace UIURescueSquad
         public int UIUAgentLife { get; set; } = 175;
         [Description("The items UIUs agents spawn with.")]
         public List<ItemType> UIUAgentInventory { get; set; } = new List<ItemType>() { ItemType.KeycardNTFLieutenant, ItemType.GunProject90, ItemType.GunUSP, ItemType.Disarmer, ItemType.Medkit, ItemType.Adrenaline, ItemType.Radio, ItemType.GrenadeFrag };
+
+        [Description("Ammo UIUs agents spawn with. (5.56, 7.62, 9mm)")]
+        public List<uint> UIUAgentAmmo { get; set; } = new List<uint>
+        {
+            80,0,100
+        };
+
         [Description("UIU Agent Rank (THE BADGE ON THE LIST)")]
         public string UIUAgentRank { get; set; } = "UIU Agent";
 
@@ -52,6 +66,13 @@ namespace UIURescueSquad
         public int UIULeaderLife { get; set; } = 215;
         [Description("The items UIU leader spawn with.")]
         public List<ItemType> UIULeaderInventory { get; set; } = new List<ItemType>() { ItemType.KeycardNTFLieutenant, ItemType.GunProject90, ItemType.GunUSP, ItemType.Disarmer, ItemType.Medkit, ItemType.Adrenaline, ItemType.Radio, ItemType.GrenadeFrag };
+
+        [Description("Ammo UIUs leader spawn with. (5.56, 7.62, 9mm)")]
+        public List<uint> UIULeaderAmmo { get; set; } = new List<uint>
+        {
+            80,0,100
+        };
+
         [Description("UIU Leader Rank (THE BADGE ON THE LIST)")]
         public string UIULeaderRank { get; set; } = "UIU Leader";
     }

--- a/Config.cs
+++ b/Config.cs
@@ -1,4 +1,4 @@
-﻿using Exiled.API.Interfaces;
+using Exiled.API.Interfaces;
 using System.Collections.Generic;
 using System.ComponentModel;
 
@@ -34,9 +34,12 @@ namespace UIURescueSquad
         [Description("UIU Player broadcast (null to disable it)")]
         public ushort UIUBroadcastTime { get; set; } = 10;
 
+
+
+
         [Description("UIU Soldier life (NTF CADET)")]
         public int UIUSoldierLife { get; set; } = 160;
-        [Description("The items UIUs soldiers spawn with.")]
+        [Description("The items UIUs soldiers spawn with")]
         public List<ItemType> UIUSoldierInventory { get; set; } = new List<ItemType>() { ItemType.KeycardNTFLieutenant, ItemType.GunProject90, ItemType.GunUSP, ItemType.Disarmer, ItemType.Medkit, ItemType.Adrenaline, ItemType.Radio, ItemType.GrenadeFrag };
 
         [Description("Ammo UIUs soldiers spawn with. (5.56, 7.62, 9mm)")]
@@ -44,23 +47,25 @@ namespace UIURescueSquad
         {
             80,0,100
         };
-
-        [Description("UIU Soldier Rank (THE BADGE ON THE LIST)")]
+        [Description("UIU Soldier Rank (instead of Nine-Tailed Fox Cadet role)")]
         public string UIUSoldierRank { get; set; } = "UIU Soldier";
+
+
 
         [Description("UIU Agent life (NTF LIEUTENANT)")]
         public int UIUAgentLife { get; set; } = 175;
-        [Description("The items UIUs agents spawn with.")]
+        [Description("The items UIUs agents spawn with")]
         public List<ItemType> UIUAgentInventory { get; set; } = new List<ItemType>() { ItemType.KeycardNTFLieutenant, ItemType.GunProject90, ItemType.GunUSP, ItemType.Disarmer, ItemType.Medkit, ItemType.Adrenaline, ItemType.Radio, ItemType.GrenadeFrag };
 
-        [Description("Ammo UIUs agents spawn with. (5.56, 7.62, 9mm)")]
+        [Description("Ammo UIUs agents spawn with (5.56, 7.62, 9mm)")]
         public List<uint> UIUAgentAmmo { get; set; } = new List<uint>
         {
             80,0,100
         };
-
-        [Description("UIU Agent Rank (THE BADGE ON THE LIST)")]
+        [Description("UIU Agent Rank (instead of Nine-Tailed Fox Lieutenant role)")]
         public string UIUAgentRank { get; set; } = "UIU Agent";
+
+
 
         [Description("UIU Leader life (NTF COMMANDER)")]
         public int UIULeaderLife { get; set; } = 215;
@@ -73,7 +78,7 @@ namespace UIURescueSquad
             80,0,100
         };
 
-        [Description("UIU Leader Rank (THE BADGE ON THE LIST)")]
+        [Description("UIU Leader Rank (instead of Nine-Tailed Fox Commander role)")]
         public string UIULeaderRank { get; set; } = "UIU Leader";
     }
 }

--- a/Config.cs
+++ b/Config.cs
@@ -77,7 +77,6 @@ namespace UIURescueSquad
         {
             80,0,100
         };
-
         [Description("UIU Leader Rank (instead of Nine-Tailed Fox Commander role)")]
         public string UIULeaderRank { get; set; } = "UIU Leader";
     }

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System.Text;
+using System.Collections.Generic;
 using Exiled.API.Features;
 using Exiled.Events.EventArgs;
 using MEC;
@@ -6,12 +7,11 @@ using UnityEngine;
 
 namespace UIURescueSquad.Handlers
 {
-    public partial class EventHandlers
+    public class EventHandlers
     {
-        public UIURescueSquad plugin;
-        public EventHandlers(UIURescueSquad plugin) => this.plugin = plugin;
+        public static bool isSpawnable;
 
-        public static List<int> uiuPlayers = new List<int>();
+        public static List<Player> uiuPlayers = new List<Player>();
 
         private int respawns = 0;
         private int randnums;
@@ -20,7 +20,6 @@ namespace UIURescueSquad.Handlers
 
         private static Vector3 SpawnPos = new Vector3(170, 985, 29);
         //NOTE: Make spawnpos configurable
-        private string rank;
 
         public void OnWaitingForPlayers()
         {
@@ -28,110 +27,177 @@ namespace UIURescueSquad.Handlers
             respawns = 0;
         }
 
+        public void IsSpawnable()
+        {
+            randnums = rand.Next(1, 101);
+            if (randnums <= UIURescueSquad.Instance.Config.probability && respawns >= UIURescueSquad.Instance.Config.respawns) isSpawnable = true;
+            else isSpawnable = false;
+        }
+
         public void OnTeamRespawn(RespawningTeamEventArgs ev)
         {
             if (ev.NextKnownTeam == Respawning.SpawnableTeamType.NineTailedFox)
             {
-                randnums = rand.Next(1, 101);
-                Log.Info(randnums);
-                if (randnums <= plugin.Config.probability & respawns >= plugin.Config.respawns)
+                //randnums = rand.Next(1, 101);
+                //Log.Info(randnums);
+                //if (randnums <= UIURescueSquad.Instance.Config.probability & respawns >= UIURescueSquad.Instance.Config.respawns)
+                if (isSpawnable)
                 {
-                    if (plugin.Config.AnnouncementText != null)
+                    if (UIURescueSquad.Instance.Config.AnnouncementText != null)
                     {
-                        if (plugin.Config.AnnouncementText != null && plugin.Config.AnnouncementText != null)
+                        if (UIURescueSquad.Instance.Config.AnnouncementText != null && UIURescueSquad.Instance.Config.AnnouncementText != null)
                         {
                             Map.ClearBroadcasts();
-                            Map.Broadcast(plugin.Config.AnnouncementTime, plugin.Config.AnnouncementText);
+                            Map.Broadcast(UIURescueSquad.Instance.Config.AnnouncementTime, UIURescueSquad.Instance.Config.AnnouncementText);
                         }
                     }
                     //Cassie.Message("Attention, the U I U HasEntered please help the MtfUnit that are AwaitingRecontainment .g7 ScpSubjects", true, true);
                     //NOTE: disable MTF entrance message to allow cassie messages
                     foreach (Player player in ev.Players)
                     {
-                        uiuPlayers.Add(player.Id);
-                        if (plugin.Config.UIUBroadcast != null && plugin.Config.UIUBroadcastTime.ToString() != null)
+                        uiuPlayers.Add(player);
+
+                        if (UIURescueSquad.Instance.Config.UIUBroadcast != null && UIURescueSquad.Instance.Config.UIUBroadcastTime.ToString() != null)
                         {
-                            if (plugin.Config.UseHintsHere)
+                            if (UIURescueSquad.Instance.Config.UseHintsHere)
                             {
-                                player.ClearBroadcasts();
-                                player.ShowHint(plugin.Config.UIUBroadcast, plugin.Config.UIUBroadcastTime);
+                                player.ShowHint(UIURescueSquad.Instance.Config.UIUBroadcast, UIURescueSquad.Instance.Config.UIUBroadcastTime);
                             }
                             else
                             {
                                 player.ClearBroadcasts();
-                                player.Broadcast(plugin.Config.UIUBroadcastTime, plugin.Config.UIUBroadcast);
+                                player.Broadcast(UIURescueSquad.Instance.Config.UIUBroadcastTime, UIURescueSquad.Instance.Config.UIUBroadcast);
                             }
                         }
-                        Timing.CallDelayed(0.01f, () => {
+
+                        Timing.CallDelayed(0.01f, () =>
+                        {
                             switch (player.Role)
                             {
                                 case RoleType.NtfCadet:
-                                    player.Health = plugin.Config.UIUSoldierLife;
-                                    Timing.CallDelayed(0.4f, () => { player.Position = SpawnPos; });
-                                    player.ResetInventory(plugin.Config.UIUSoldierInventory);
-                                    //NOTE: Add possibilities for the inventory system
-                                    player.BadgeHidden = false;
-                                    player.RankName = plugin.Config.UIUSoldierRank;
-                                    player.RankColor = "yellow";
-                                    break;
+                                    {
+                                        player.Health = UIURescueSquad.Instance.Config.UIUSoldierLife;
+
+                                        player.ResetInventory(UIURescueSquad.Instance.Config.UIUSoldierInventory);
+
+                                        for (int i = 0; i < 3; i++)
+                                        {
+                                            player.Ammo[i] = UIURescueSquad.Instance.Config.UIUSoldierAmmo[i];
+                                        }
+
+                                        player.ReferenceHub.nicknameSync.ShownPlayerInfo &= ~PlayerInfoArea.Role;
+                                        player.CustomInfo = UIURescueSquad.Instance.Config.UIUSoldierRank;
+                                        break;
+                                    }
+
                                 case RoleType.NtfLieutenant:
-                                    player.Health = plugin.Config.UIUAgentLife;
-                                    Timing.CallDelayed(0.4f, () => { player.Position = SpawnPos; });
-                                    player.ResetInventory(plugin.Config.UIUAgentInventory);
-                                    player.BadgeHidden = false;
-                                    player.RankName = plugin.Config.UIUAgentRank;
-                                    player.RankColor = "yellow";
-                                    break;
+                                    {
+                                        player.Health = UIURescueSquad.Instance.Config.UIUAgentLife;
+
+                                        player.ResetInventory(UIURescueSquad.Instance.Config.UIUAgentInventory);
+
+                                        for (int i = 0; i < 3; i++)
+                                        {
+                                            player.Ammo[i] = UIURescueSquad.Instance.Config.UIUAgentAmmo[i];
+                                        }
+
+                                        player.ReferenceHub.nicknameSync.ShownPlayerInfo &= ~PlayerInfoArea.Role;
+                                        player.CustomInfo = UIURescueSquad.Instance.Config.UIUAgentRank;
+                                        break;
+                                    }
+
                                 case RoleType.NtfCommander:
-                                    player.Health = plugin.Config.UIULeaderLife;
-                                    Timing.CallDelayed(0.4f, () => { player.Position = SpawnPos; });
-                                    player.ResetInventory(plugin.Config.UIULeaderInventory);
-                                    player.BadgeHidden = false;
-                                    player.RankName = plugin.Config.UIULeaderRank;
-                                    player.RankColor = "yellow";
-                                    break;
+                                    {
+                                        player.Health = UIURescueSquad.Instance.Config.UIULeaderLife;
+
+                                        player.ResetInventory(UIURescueSquad.Instance.Config.UIULeaderInventory);
+
+                                        for (int i = 0; i < 3; i++)
+                                        {
+                                            player.Ammo[i] = UIURescueSquad.Instance.Config.UIULeaderAmmo[i];
+                                        }
+
+                                        player.ReferenceHub.nicknameSync.ShownPlayerInfo &= ~PlayerInfoArea.Role;
+                                        player.CustomInfo = UIURescueSquad.Instance.Config.UIULeaderRank;
+                                        break;
+                                    }
                             }
+                            Timing.CallDelayed(0.4f, () => { player.Position = SpawnPos; });
                         });
                     }
                 }
-            respawns++;
+                respawns++;
             }
         }
 
         public void OnAnnouncingMTF(AnnouncingNtfEntranceEventArgs ev)
         {
-            if (randnums <= plugin.Config.probability & respawns >= plugin.Config.respawns + 1)
+            if (isSpawnable && respawns >= UIURescueSquad.Instance.Config.respawns + 1)
             {
                 ev.IsAllowed = false;
-                if (plugin.Config.DisableNTFAnnounce)
+
+                if (UIURescueSquad.Instance.Config.DisableNTFAnnounce)
                 {
-                    Cassie.Message(plugin.Config.AnnouncementCassie);
+                    if (ev.ScpsLeft == 0)
+                    {
+                        Cassie.GlitchyMessage(UIURescueSquad.Instance.Config.AnnouncmentCassieNoScp, 0.5f, 0.5f);
+                    }
+
+                    else
+                    {
+                        StringBuilder message = new StringBuilder();
+
+                        message.Append(UIURescueSquad.Instance.Config.AnnouncementCassie);
+                        message.Replace("{scpnum}", ev.ScpsLeft.ToString());
+
+                        Cassie.GlitchyMessage(message.ToString(), 0.5f, 0.5f);
+                    }
                 }
+            }
+        }
+
+
+
+
+        public void OnLeft(LeftEventArgs ev)
+        {
+            if (uiuPlayers.Contains(ev.Player))
+            {
+                KillUIU(ev.Player);
             }
         }
 
         public void OnDying(DiedEventArgs ev)
         {
-            if (uiuPlayers.Contains(ev.Target.Id))
+            if (uiuPlayers.Contains(ev.Target))
             {
-                //NOTE: Fix this shit fix
-                //Block users from using hidetag/showtag beeing UIU
-                uiuPlayers.Remove(ev.Target.Id);
-                ev.Target.ReferenceHub.serverRoles.NetworkMyText = rank;
-                ev.Target.ReferenceHub.serverRoles.NetworkMyColor = "default";
-                ev.Target.BadgeHidden = false;
+                KillUIU(ev.Target);
             }
         }
         public void OnChanging(ChangingRoleEventArgs ev)
         {
-            if (uiuPlayers.Contains(ev.Player.Id))
+            if (uiuPlayers.Contains(ev.Player) && ev.Player.Role != RoleType.Spectator)
             {
-                //NOTE: Fix this shit fix
-                uiuPlayers.Remove(ev.Player.Id);
-                ev.Player.ReferenceHub.serverRoles.NetworkMyText = rank;
-                ev.Player.ReferenceHub.serverRoles.NetworkMyColor = "default";
-                ev.Player.BadgeHidden = false;
+                KillUIU(ev.Player);
             }
         }
+
+
+        public void KillUIU(Player player)
+        {
+            player.CustomInfo = string.Empty;
+            player.ReferenceHub.nicknameSync.ShownPlayerInfo |= PlayerInfoArea.Role;
+
+            uiuPlayers.Remove(player);
+        }
     }
+
+    //Added LazyInstance (this was neccesary for making your plugin compatibile with my RespawnTimer plugin, if you don't want that you can get rid of it)
+    //Replaced badges with custominfo
+    //Added ammo config for classes
+    //Cleaned up code (in main class I registered events in a shorter way)
+    //uiuPlayers holds actual players, not id numbers (requiered for Custom Player Info)
+    //Added KillUIU function which make deleting uiuPlayers from list easier
+    //Remade Cassie announcment message. There are 2 diffrent configurable cassie announcments (one for when SCPs are dead). Cassie be also be glitchy meaing there is by default 5 % chance of jamming or .g(num)
+    //Get rid of unused UseHints option in Config and string Rank in EventHandlers
 }

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -1,4 +1,4 @@
-﻿using System.Text;
+using System.Text;
 using System.Collections.Generic;
 using Exiled.API.Features;
 using Exiled.Events.EventArgs;
@@ -148,7 +148,8 @@ namespace UIURescueSquad.Handlers
                         StringBuilder message = new StringBuilder();
 
                         message.Append(UIURescueSquad.Instance.Config.AnnouncementCassie);
-                        message.Replace("{scpnum}", ev.ScpsLeft.ToString());
+                        message.Replace("{scpnum}", $"{ev.ScpsLeft} scpsubject");
+                        if (ev.ScpsLeft > 1) message.Append("s");
 
                         Cassie.GlitchyMessage(message.ToString(), 0.05f, 0.05f);
                     }

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -191,13 +191,4 @@ namespace UIURescueSquad.Handlers
             uiuPlayers.Remove(player);
         }
     }
-
-    //Added LazyInstance (this was neccesary for making your plugin compatibile with my RespawnTimer plugin, if you don't want that you can get rid of it)
-    //Replaced badges with custominfo
-    //Added ammo config for classes
-    //Cleaned up code (in main class I registered events in a shorter way)
-    //uiuPlayers holds actual players, not id numbers (requiered for Custom Player Info)
-    //Added KillUIU function which make deleting uiuPlayers from list easier
-    //Remade Cassie announcment message. There are 2 diffrent configurable cassie announcments (one for when SCPs are dead). Cassie be also be glitchy meaing there is by default 5 % chance of jamming or .g(num)
-    //Get rid of unused UseHints option in Config and string Rank in EventHandlers
 }

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -150,7 +150,7 @@ namespace UIURescueSquad.Handlers
                         message.Append(UIURescueSquad.Instance.Config.AnnouncementCassie);
                         message.Replace("{scpnum}", ev.ScpsLeft.ToString());
 
-                        Cassie.GlitchyMessage(message.ToString(), 0.5f, 0.5f);
+                        Cassie.GlitchyMessage(message.ToString(), 0.05f, 0.05f);
                     }
                 }
             }

--- a/EventHandlers.cs
+++ b/EventHandlers.cs
@@ -140,7 +140,7 @@ namespace UIURescueSquad.Handlers
                 {
                     if (ev.ScpsLeft == 0)
                     {
-                        Cassie.GlitchyMessage(UIURescueSquad.Instance.Config.AnnouncmentCassieNoScp, 0.5f, 0.5f);
+                        Cassie.GlitchyMessage(UIURescueSquad.Instance.Config.AnnouncmentCassieNoScp, 0.05f, 0.05f);
                     }
 
                     else

--- a/Patches/UIUSpawn.cs
+++ b/Patches/UIUSpawn.cs
@@ -1,0 +1,16 @@
+﻿using HarmonyLib;
+
+namespace UIURescueSquad.Patches
+{
+    [HarmonyPatch(typeof(Respawning.RespawnTickets), nameof(Respawning.RespawnTickets.DrawRandomTeam))]
+    class UIUSpawn
+    {
+        public static void Postfix(ref Respawning.SpawnableTeamType __result)
+        {
+            if (__result == Respawning.SpawnableTeamType.NineTailedFox)
+            {
+                UIURescueSquad.Instance.EventHandlers.IsSpawnable();
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -7,28 +7,30 @@ Download the .dll file of the latest release and place it inside the Exiled Plug
 # Configs
 ```yaml
 UIURescueSquad:
-  # Is the plugin enabled?
+# Is the plugin enabled?
   is_enabled: true
-
-  # How many times mtfs must have respawn to spawn UIU
+  # How many mtfs respawns must have happened to spawn UIU
   respawns: 1
   # Probability of a UIU Squad replacing a MTF spawn
   probability: 50
-
-  # Use hints instead of broadcasts?
-  use_hints: false
-  # Entrance announcement message (null to disable it)
+  # Entrance broadcast announcement message (null to disable it)
   announcement_text: <b>The <color=#FFFA4B>UIU Rescue Squad</color> has arrived to the facility</b>
-  # Entrance announcement message time
+  # Entrance broadcast announcement message time
   announcement_time: 10
+  # Disable NTF default Announce
+  disable_n_t_f_announce: true
+  # **ONLY WORKS IF DisableNTFAnnounce = true** Entrance Cassie Message
+  announcement_cassie: The U I U Squad HasEntered AwaitingRecontainment {scpnum}
+  announcment_cassie_no_scp: The U I U Squad HasEntered NoSCPsLeft
+  # Use hints instead of broadcasts?
+  use_hints_here: false
   # UIU Player broadcast (null to disable it)
   u_i_u_broadcast: <i>You are an</i><color=yellow><b> UIU trooper</b></color>, <i>help </i><color=#0377fc><b>MTFs</b></color><i> to finish its job</i>
   # UIU Player broadcast (null to disable it)
   u_i_u_broadcast_time: 10
-
   # UIU Soldier life (NTF CADET)
   u_i_u_soldier_life: 160
-  # The items UIUs soldiers spawn with.
+  # The items UIUs soldiers spawn with
   u_i_u_soldier_inventory:
   - KeycardNTFLieutenant
   - GunProject90
@@ -38,12 +40,16 @@ UIURescueSquad:
   - Adrenaline
   - Radio
   - GrenadeFrag
-  # UIU Soldier Rank (THE BADGE ON THE LIST)
+  # Ammo UIUs soldiers spawn with. (5.56, 7.62, 9mm)
+  u_i_u_soldier_ammo:
+  - 80
+  - 0
+  - 100
+  # UIU Soldier Rank (instead of Nine-Tailed Fox Cadet role)
   u_i_u_soldier_rank: UIU Soldier
-
   # UIU Agent life (NTF LIEUTENANT)
   u_i_u_agent_life: 175
-  # The items UIUs agents spawn with.
+  # The items UIUs agents spawn with
   u_i_u_agent_inventory:
   - KeycardNTFLieutenant
   - GunProject90
@@ -53,9 +59,13 @@ UIURescueSquad:
   - Adrenaline
   - Radio
   - GrenadeFrag
-  # UIU Agent Rank (THE BADGE ON THE LIST)
+  # Ammo UIUs agents spawn with (5.56, 7.62, 9mm)
+  u_i_u_agent_ammo:
+  - 80
+  - 0
+  - 100
+  # UIU Agent Rank (instead of Nine-Tailed Fox Lieutenant role)
   u_i_u_agent_rank: UIU Agent
-
   # UIU Leader life (NTF COMMANDER)
   u_i_u_leader_life: 215
   # The items UIU leader spawn with.
@@ -68,6 +78,11 @@ UIURescueSquad:
   - Adrenaline
   - Radio
   - GrenadeFrag
-  # UIU Leader Rank (THE BADGE ON THE LIST)
+  # Ammo UIUs leader spawn with. (5.56, 7.62, 9mm)
+  u_i_u_leader_ammo:
+  - 80
+  - 0
+  - 100
+  # UIU Leader Rank (instead of Nine-Tailed Fox Commander role)
   u_i_u_leader_rank: UIU Leader
 ```

--- a/UIURescueSquad.csproj
+++ b/UIURescueSquad.csproj
@@ -32,59 +32,77 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="0Harmony">
-      <HintPath>..\..\Referencias\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.0.4.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\0Harmony.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-firstpass, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="Assembly-CSharp-Publicized">
-      <HintPath>..\..\Referencias\Assembly-CSharp-Publicized.dll</HintPath>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\Assembly-CSharp-Publicized.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.API, Version=2.1.3.0, Culture=neutral, processorArchitecture=AMD64">
+    <Reference Include="CommandSystem.Core, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Referencias\Exiled.API.dll</HintPath>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\CommandSystem.Core.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Events, Version=2.1.3.0, Culture=neutral, processorArchitecture=AMD64">
+    <Reference Include="Exiled.API, Version=2.1.21.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Referencias\Exiled.Events.dll</HintPath>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\Exiled.API.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Loader, Version=2.1.3.0, Culture=neutral, processorArchitecture=AMD64">
+    <Reference Include="Exiled.Events, Version=2.1.21.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Referencias\Exiled.Loader.dll</HintPath>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\Exiled.Events.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Permissions, Version=2.1.3.0, Culture=neutral, processorArchitecture=AMD64">
+    <Reference Include="Exiled.Loader, Version=2.1.21.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Referencias\Exiled.Permissions.dll</HintPath>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\Exiled.Loader.dll</HintPath>
     </Reference>
-    <Reference Include="Exiled.Updater, Version=3.0.2.0, Culture=neutral, processorArchitecture=AMD64">
+    <Reference Include="Exiled.Permissions, Version=2.1.21.0, Culture=neutral, processorArchitecture=AMD64">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\Referencias\Exiled.Updater.dll</HintPath>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\Exiled.Permissions.dll</HintPath>
     </Reference>
-    <Reference Include="Mirror">
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\Mirror.dll</HintPath>
+    <Reference Include="Exiled.Updater, Version=3.0.3.0, Culture=neutral, processorArchitecture=AMD64">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\Exiled.Updater.dll</HintPath>
+    </Reference>
+    <Reference Include="Mirror, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\Mirror.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NorthwoodLib, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\NorthwoodLib.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="Microsoft.CSharp" />
     <Reference Include="System.Data" />
     <Reference Include="System.Net.Http" />
     <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine">
+      <HintPath>..\..\Exiled Stuff\Exiled dll\UnityEngine.dll</HintPath>
+    </Reference>
     <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\..\..\..\..\..\Program Files (x86)\Steam\steamapps\common\SCP Secret Laboratory Dedicated Server\SCPSL_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\UnityEngine.CoreModule.dll</HintPath>
     </Reference>
-    <Reference Include="YamlDotNet">
-      <HintPath>..\..\Referencias\YamlDotNet.dll</HintPath>
+    <Reference Include="YamlDotNet, Version=8.0.0.0, Culture=neutral, PublicKeyToken=ec19458f3c15af5e, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Exiled Stuff\Exiled dll\YamlDotNet.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Config.cs" />
     <Compile Include="EventHandlers.cs" />
+    <Compile Include="Patches\UIUSpawn.cs" />
     <Compile Include="UIURescueSquad.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/UIURescueSquad.sln
+++ b/UIURescueSquad.sln
@@ -1,0 +1,25 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.30523.141
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UIURescueSquad", "UIURescueSquad.csproj", "{1A4CA600-7BEE-4A95-A353-9E556DE3ED1C}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{1A4CA600-7BEE-4A95-A353-9E556DE3ED1C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1A4CA600-7BEE-4A95-A353-9E556DE3ED1C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1A4CA600-7BEE-4A95-A353-9E556DE3ED1C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1A4CA600-7BEE-4A95-A353-9E556DE3ED1C}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {DC5A4981-D82E-451E-9DAC-CCEE206F1B3C}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Changelog:
 - Added UIUSpawn patch (support for RespawnTimer)
 - Added LazyInstance (this was neccesary for making your plugin compatibile with my RespawnTimer plugin, if you don't want that you can get rid of it)
 - Replaced badges with custominfo
 - Added ammo config for classes
 - Cleaned up code (in main class I registered events in a shorter way)
 - uiuPlayers holds actual players, not id numbers (requiered for Custom Player Info)
 - Added KillUIU function which make deleting uiuPlayers from list easier
 - Remade Cassie announcment message. There are 2 diffrent configurable cassie announcments (one for when SCPs are dead). Cassie be also be glitchy meaing there is by default 5 % chance of jamming or .g(num)
 - Get rid of unused UseHints option in Config and string Rank in EventHandlers